### PR TITLE
Bug : Text Forms in Contact Us Section Not Visible in Light Mode#292

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -367,6 +367,7 @@ body {
 /* send button end */
 
 .btn:hover {
+  color: var(--body-light);
   background-color: var(--primary-color-dark);
 }
 
@@ -1340,8 +1341,8 @@ header {
   border: none;
   font-size: 15px;
   background: none;
-  border-bottom: 2px solid var(--extra-light);
-  color: var(--extra-light);
+  border-bottom: 2px solid var(--foot-light);
+  color: var(--foot-light);
   font-family: 'Oxygen', sans-serif;
 }
 
@@ -1354,7 +1355,7 @@ header {
 }
 
 .contact-form h4 {
-  color: var(--extra-light);
+  color: var(--foot-light);
   font-weight: 300;
   font-size: 15px;
   font-family: 'Oxygen', sans-serif;
@@ -1369,8 +1370,8 @@ header {
   margin: 20px;
   margin-top: 10px;
   margin-left: 30px;
-  border-bottom: 2px solid var(--extra-light);
-  color: var(--extra-light);
+  border-bottom: 2px solid var(--foot-light);
+  color: var(--foot-light);
   font-weight: 200;
   font-size: 15px;
   outline: none;
@@ -1379,6 +1380,10 @@ header {
 
 textarea::-webkit-scrollbar {
   width: 1em;
+}
+
+.contact-form button{
+  color: var(--foot-light) !important;
 }
 
 /* .contact-form #button{
@@ -1890,3 +1895,4 @@ body {
 #toggle:hover i {
   color: #ffffff80; /* 80% opacity white for hovering effect */
 }
+


### PR DESCRIPTION


# Title and Issue number 
Title :  Text Forms in Contact Us Section Not Visible in Light Mode

Issue No. : 292

Code Stack : 

Close #<issue_no>
<!-- Example Close #292   -->
<!-- Replace `292` with the issue number which is fixed in this PR -->


# Video/Screenshots (mandatory)

Before Solving Bug:

![Before](https://github.com/apu52/Travel_Website/assets/102939018/54385d05-cc2e-485b-9806-a5df6baeffb5)


After Solving Bug:
![after](https://github.com/apu52/Travel_Website/assets/102939018/de06bad3-410b-4dad-969e-04f90e5bd218)
<!-- It is not applicable for the templates of adding feature or fixing bugs -->

# Checklist:

- [X] I have mentioned the issue number in my Pull Request.
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have gone through the  `contributing.md` file before contributing
<!-- [X] - put a cross/X inside [] to check the box -->





