### PR TITLE
Remove margin from paragraphs under about us section

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,25 +192,25 @@
                 }
               </style>
               <p class="aboutcontent" data-aos="fade-in" style="text-align: justify;">
-                <span style="margin-left: 80px;"></span>Welcome to TourGuide, where we firmly believe that life's true purpose unfolds amidst the thrill of exploration, the embrace of the unfamiliar, and the pursuit of the extraordinary! Our mission is to embolden you, the intrepid traveler, to unveil this purpose and elevate your journey by providing unparalleled assistance and guidance. Let us be your compass as you navigate through the wonders of the world, forging unforgettable memories and discovering the essence of travel!
+                Welcome to TourGuide, where we firmly believe that life's true purpose unfolds amidst the thrill of exploration, the embrace of the unfamiliar, and the pursuit of the extraordinary! Our mission is to embolden you, the intrepid traveler, to unveil this purpose and elevate your journey by providing unparalleled assistance and guidance. Let us be your compass as you navigate through the wonders of the world, forging unforgettable memories and discovering the essence of travel!
               </p>
 
               <p class="aboutcontent" data-aos="fade-in" style="text-align: justify;">
-                <span style="margin-left: 80px;"></span> At TourGuide, our local guides serve as your passport to effortlessly navigate through local
+                At TourGuide, our local guides serve as your passport to effortlessly navigate through local
                 languages, customs, and traditions that often make traveling to a foreign place overwhelming. We
                 provide curated travel itineraries, once-in-a-lifetime experiences, valuable travel advice, and the
                 freedom to customize itineraries to ensure everything aligns with your wishlist.
               </p>
 
               <p class="aboutcontent" data-aos="fade-in" style="text-align: justify;">
-                <span style="margin-left: 80px;"></span>Since our inception in 2024, TourGuide has cultivated a dynamic travel community, with 30,000+
+                Since our inception in 2024, TourGuide has cultivated a dynamic travel community, with 30,000+
                 guides hailing from over 200+ countries globally. We continue to grow each day, expanding the
                 horizons of possibilities for discovering the world. With TourGuide by your side, there's no limit
                 to the different ways you can embark on an unforgettable journey!
               </p>
 
               <p class="aboutcontent" data-aos="fade-in" style="text-align: justify;">
-                <strong><span style="margin-left: 80px;"></span> We welcome you to the TourGuide family - where every journey becomes a story worth
+                <strong>We welcome you to the TourGuide family - where every journey becomes a story worth
                   sharing!</strong>
               </p>
             </article>


### PR DESCRIPTION
Title : Bug in About Us Section

Issue No. : #601 

Code Stack : HTML

Close #601 

I have removed the extra left margin from all the paragraphs under about us section.


Before:
![image](https://github.com/apu52/Travel_Website/assets/91290891/d1f92763-2e8b-46e2-b1e8-f7199a541dc0)

![image](https://github.com/apu52/Travel_Website/assets/91290891/3c885576-526d-4ae8-ac7b-a0f6a00f0b07)


After:
![image](https://github.com/apu52/Travel_Website/assets/91290891/5f46fe9e-8bc0-412e-a3d3-01e6235374cd)

![image](https://github.com/apu52/Travel_Website/assets/91290891/f99e1339-988d-49fa-b901-8693140055f1)





- [X] I have mentioned the issue number in my Pull Request.
- [X] I have gone through the  `contributing.md` file before contributing


I am contributing under GSSOC'24.




