### PR TITLE
Added Date Validation to Plan a trip page #611

### DIFF
--- a/plantrip.html
+++ b/plantrip.html
@@ -110,7 +110,7 @@
        <script>
         function handleSubmit(event) {
             event.preventDefault();
-            const today = new Date(); 
+            const today = new Date(); // Get today's date
             const startDate = new Date(document.getElementById('startDate').value);
             const endDate = new Date(document.getElementById('endDate').value);
 
@@ -120,7 +120,8 @@
                 alert('Start and end dates cannot be earlier than today.');
             } else {
                 alert('Trip planned successfully!');
-                
+                // You can proceed to submit the form or perform other actions here
+                // For demonstration, form submission is prevented.
             }
         }
 

--- a/plantrip.html
+++ b/plantrip.html
@@ -107,18 +107,20 @@
             outline: none;
         }
     </style>
-    <script>
+       <script>
         function handleSubmit(event) {
             event.preventDefault();
+            const today = new Date(); 
             const startDate = new Date(document.getElementById('startDate').value);
             const endDate = new Date(document.getElementById('endDate').value);
 
             if (endDate < startDate) {
                 alert('End date cannot be earlier than start date.');
+            } else if (startDate < today || endDate < today) {
+                alert('Start and end dates cannot be earlier than today.');
             } else {
                 alert('Trip planned successfully!');
-                // You can proceed to submit the form or perform other actions here
-                // For demonstration, form submission is prevented.
+                
             }
         }
 


### PR DESCRIPTION
# Title and Issue number 

Title : Date Validation for Plan a trip page

Issue No. : #611 

Code Stack : HTML | JS

Close #611 

# Video/Screenshots 

 **Before Date Validation**
![image](https://github.com/apu52/Travel_Website/assets/110184554/3062aab1-3385-4e14-807a-e3f7bb53abca)

**After Date Validation** 
(If an earlier date is selected an alert message is popped up)
<img width="547" alt="image" src="https://github.com/apu52/Travel_Website/assets/110184554/853ac361-09aa-46bb-82c0-90fe9751e22b">

(For a future date)
<img width="560" alt="image" src="https://github.com/apu52/Travel_Website/assets/110184554/37758f77-d3b1-4e80-9e26-42d7e670a1b6">

# Checklist:

- [X] I have mentioned the issue number in my Pull Request.
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have gone through the  `contributing.md` file before contributing

**Additional context**
The date is validated in Plan a trip page. The trip won't get planned for a past date. 

***Are you contributing under any Open-source programme?***
I am a GSSOC'24 Contributor

