### PR TITLE
fix: Images added in the Explore top destinations section #586 

### DIFF
--- a/index.html
+++ b/index.html
@@ -400,95 +400,87 @@
     </div>
 
     <!-- slideshow -->
-    <!-- <div class="slideshow-container" data-aos="fade-up"> -->
+<!-- <div class="slideshow-container" data-aos="fade-up"> -->
 
-    <!-- Next and previous buttons -->
-    <!-- <div class="destination__nav">
-          <span onclick="pullSlide(-1)"><i class="ri-arrow-left-s-line"></i></span>
-          <span onclick="pullSlide(1)"><i class="ri-arrow-right-s-line"></i></span>
-        </div> -->
+<!-- Next and previous buttons -->
+<!-- <div class="destination__nav">
+      <span onclick="pullSlide(-1)"><i class="ri-arrow-left-s-line"></i></span>
+      <span onclick="pullSlide(1)"><i class="ri-arrow-right-s-line"></i></span>
+    </div> -->
 
-    <!-- Full-width images with number and caption text -->
-    <!-- <div class="mySlides">
-          <img src="./img/eiffelTower.webp" style="width:100%">
-        </div>
+<!-- Full-width images with number and caption text -->
+<!-- <div class="mySlides">
+      <img src="./img/eiffelTower.webp" style="width:100%">
+    </div>
 
-        <div class="mySlides">
-          <img src="./img/london.jpg" style="width:100%">
-        </div>
+    <div class="mySlides">
+      <img src="./img/london.jpg" style="width:100%">
+    </div>
 
-        <div class="mySlides">
-          <img src="./img/goa.jpg" style="width:100%">
-        </div>
+    <div class="mySlides">
+      <img src="./img/goa.jpg" style="width:100%">
+    </div>
 
-        <div class="mySlides">
-          <img src="./img/maldives.jpg" style="width:100%">
-        </div>
-        <div class="imageDots">
-          <span class="active"></span>
-          <span></span>
-          <span></span>
-          <span></span>
-        </div>
-      </div> -->
-    <div class="outer-box">
-      <div class="containers">
-
-        <div class="card active" style="
-            background-image: linear-gradient(0deg, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 1) 7%, rgba(255, 255, 255, 0) 50%),
-              url('/img/paris.jpg')
-          ">
-          <div class="info">
-
-            <p>
-              ||Eiffel Tower||
-            </p>
-            <h3>PARIS</h3>
-          </div>
-        </div>
-
-        <div class="card" style="
-              background-image: linear-gradient(0deg, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 1) 7%, rgba(255, 255, 255, 0) 50%),
-                url('/img/london.jpg')
-            ">
-          <div class="info">
-
-            <p>
-              ||Giant Wheel||
-            </p>
-            <h3>LONDON</h3>
-          </div>
-        </div>
-
-        <div class="card" style="
-              background-image: linear-gradient(0deg, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 1) 7%, rgba(255, 255, 255, 0) 50%),
-                url('/img/goa.jpg')
-            ">
-          <div class="info">
-
-            <p>
-              ||Goa Beach||
-            </p>
-            <h3>GOA</h3>
-          </div>
-        </div>
-
-        <div class="card" style="
-              background-image: linear-gradient(0deg, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 1) 7%, rgba(255, 255, 255, 0) 50%),
-                url('/img/maldives.jpg')">
-          <div class="info">
-
-            <p>
-              ||Male Beach||
-            </p>
-            <h3>MALDIVES</h3>
-          </div>
-        </div>
-
-
-
+    <div class="mySlides">
+      <img src="./img/maldives.jpg" style="width:100%">
+    </div>
+    <div class="imageDots">
+      <span class="active"></span>
+      <span></span>
+      <span></span>
+      <span></span>
+    </div>
+  </div> -->
+<div class="outer-box">
+  <div class="containers">
+    
+    <div class="card active" style="
+      background-image: linear-gradient(0deg, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 1) 7%, rgba(255, 255, 255, 0) 50%),
+        url('./img/eiffelTower.webp')
+    ">
+      <div class="info">
+        <img src="./img/eiffelTower.webp" alt="Eiffel Tower" style="width:100%">
+        <p>||Eiffel Tower||</p>
+        <h3>PARIS</h3>
       </div>
     </div>
+
+    <div class="card" style="
+      background-image: linear-gradient(0deg, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 1) 7%, rgba(255, 255, 255, 0) 50%),
+        url('./img/london.jpg')
+    ">
+      <div class="info">
+        <img src="./img/london.jpg" alt="Giant Wheel" style="width:100%">
+        <p>||Giant Wheel||</p>
+        <h3>LONDON</h3>
+      </div>
+    </div>
+
+    <div class="card" style="
+      background-image: linear-gradient(0deg, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 1) 7%, rgba(255, 255, 255, 0) 50%),
+        url('./img/goa.jpg')
+    ">
+      <div class="info">
+        <img src="./img/goa.jpg" alt="Goa Beach" style="width:100%">
+        <p>||Goa Beach||</p>
+        <h3>GOA</h3>
+      </div>
+    </div>
+
+    <div class="card" style="
+      background-image: linear-gradient(0deg, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 1) 7%, rgba(255, 255, 255, 0) 50%),
+        url('./img/maldives.jpg')
+    ">
+      <div class="info">
+        <img src="./img/maldives.jpg" alt="Male Beach" style="width:100%">
+        <p>||Male Beach||</p>
+        <h3>MALDIVES</h3>
+      </div>
+    </div>
+
+  </div>
+</div>
+
     <script src="explore.js"></script>
     </section>
 


### PR DESCRIPTION
# Title and Issue number 
Title : Images added in the Explore top destinations section

Issue No. : #586 

Code Stack : HTML | CSS

Close #586 

# Description
Images for each of the destinations are added in the explore top destinations section. Along with it, the background of each card is added with the same image.

# Screenshots
<img width="898" alt="image" src="https://github.com/apu52/Travel_Website/assets/110184554/1339b68f-489e-4941-9d71-2b1764029ba3">


# Type of PR

- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [X] Other (specify):  Since the old PR had merge conflicts this is a new PR. The old PR is #705.


# Checklist:

- [X] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have gone through the  `contributing.md` file before contributing


# Additional context:
Since the old PR had merge conflicts this is a new PR. The old PR is #705.

*Are you contributing under any Open-source programme?*
I am a GSSOC'24 Contributor





