### PR TITLE
fix: Underline in the logoname in the links of each destination of the "Best trip package" #587

### DIFF
--- a/dedicated-destinations/Dubai/start.html
+++ b/dedicated-destinations/Dubai/start.html
@@ -30,7 +30,7 @@
     --->
   <div class="nav-container">
     <nav class="newNav">
-      <a href="#" class="nav__logo" data-aos="fade-right">Tourguide<span>.</span></a>
+      <a href="#" class="nav__logo" data-aos="fade-right" style="text-decoration: none;">Tourguide<span>.</span></a>
 
       <ul class="navLinks">
         <li class="link home" data-aos="fade-down"><a href="../../index.html#Home">Home</a></li>

--- a/dedicated-destinations/Goa/start.html
+++ b/dedicated-destinations/Goa/start.html
@@ -30,7 +30,7 @@
     --->
   <div class="nav-container">
     <nav class="newNav">
-      <a href="#" class="nav__logo" data-aos="fade-right">Tourguide<span>.</span></a>
+      <a href="#" class="nav__logo" data-aos="fade-right" style="text-decoration: none;">Tourguide<span>.</span></a>
 
       <ul class="navLinks">
         <li class="link home" data-aos="fade-down"><a href="../../index.html#Home">Home</a></li>

--- a/dedicated-destinations/London/start.html
+++ b/dedicated-destinations/London/start.html
@@ -30,7 +30,7 @@
     --->
   <div class="nav-container">
     <nav class="newNav">
-      <a href="#" class="nav__logo" data-aos="fade-right">Tourguide<span>.</span></a>
+      <a href="#" class="nav__logo" data-aos="fade-right" style="text-decoration: none;">Tourguide<span>.</span></a>
 
       <ul class="navLinks">
         <li class="link home" data-aos="fade-down"><a href="../../index.html">Home</a></li>

--- a/dedicated-destinations/Maldives/start.html
+++ b/dedicated-destinations/Maldives/start.html
@@ -30,7 +30,7 @@
     --->
   <div class="nav-container">
     <nav class="newNav">
-      <a href="#" class="nav__logo" data-aos="fade-right">Tourguide<span>.</span></a>
+      <a href="#" class="nav__logo" data-aos="fade-right" style="text-decoration: none;">Tourguide<span>.</span></a>
 
       <ul class="navLinks">
         <li class="link home" data-aos="fade-down"><a href="../../index.html#Home">Home</a></li>

--- a/dedicated-destinations/Paris/start.html
+++ b/dedicated-destinations/Paris/start.html
@@ -30,7 +30,7 @@
     --->
   <div class="nav-container">
     <nav class="newNav">
-      <a href="#" class="nav__logo" data-aos="fade-right">Tourguide<span>.</span></a>
+      <a href="#" class="nav__logo" data-aos="fade-right" style="text-decoration: none;">Tourguide<span>.</span></a>
 
       <ul class="navLinks">
         <li class="link home" data-aos="fade-down"><a href="../../index.html#Home">Home</a></li>

--- a/dedicated-destinations/bali/start.html
+++ b/dedicated-destinations/bali/start.html
@@ -30,7 +30,7 @@
     --->
   <div class="nav-container">
     <nav class="newNav">
-      <a href="#" class="nav__logo" data-aos="fade-right">Tourguide<span>.</span></a>
+      <a href="#" class="nav__logo" data-aos="fade-right" style="text-decoration: none;">Tourguide<span>.</span></a>
 
       <ul class="navLinks">
         <li class="link home" data-aos="fade-down"><a href="../../index.html#Home">Home</a></li>

--- a/dedicated-destinations/brazil/start.html
+++ b/dedicated-destinations/brazil/start.html
@@ -30,7 +30,7 @@
     --->
   <div class="nav-container">
     <nav class="newNav">
-      <a href="#" class="nav__logo" data-aos="fade-right">Tourguide<span>.</span></a>
+      <a href="#" class="nav__logo" data-aos="fade-right" style="text-decoration: none;">Tourguide<span>.</span></a>
 
       <ul class="navLinks">
         <li class="link home" data-aos="fade-down"><a href="../../index.html#Home">Home</a></li>

--- a/dedicated-destinations/grand-canyon-national-park-arizona/Grand_start.html
+++ b/dedicated-destinations/grand-canyon-national-park-arizona/Grand_start.html
@@ -30,7 +30,7 @@
     --->
   <div class="nav-container">
     <nav class="newNav">
-      <a href="#" class="nav__logo" data-aos="fade-right">Tourguide<span>.</span></a>
+      <a href="#" class="nav__logo" data-aos="fade-right" style="text-decoration: none;">Tourguide<span>.</span></a>
 
       <ul class="navLinks">
         <li class="link home" data-aos="fade-down"><a href="../../index.html#Home">Home</a></li>

--- a/dedicated-destinations/kashmir/start.html
+++ b/dedicated-destinations/kashmir/start.html
@@ -30,7 +30,7 @@
     --->
   <div class="nav-container">
     <nav class="newNav">
-      <a href="#" class="nav__logo" data-aos="fade-right">Tourguide<span>.</span></a>
+      <a href="#" class="nav__logo" data-aos="fade-right" style="text-decoration: none;">Tourguide<span>.</span></a>
 
       <ul class="navLinks">
         <li class="link home" data-aos="fade-down"><a href="../../index.html">Home</a></li>

--- a/dedicated-destinations/machu-picchu-peru/Machu_start.html
+++ b/dedicated-destinations/machu-picchu-peru/Machu_start.html
@@ -30,7 +30,7 @@
     --->
   <div class="nav-container">
     <nav class="newNav">
-      <a href="#" class="nav__logo" data-aos="fade-right">Tourguide<span>.</span></a>
+      <a href="#" class="nav__logo" data-aos="fade-right" style="text-decoration: none;">Tourguide<span>.</span></a>
 
       <ul class="navLinks">
         <li class="link home" data-aos="fade-down"><a href="../../index.html">Home</a></li>

--- a/dedicated-destinations/new-york/start.html
+++ b/dedicated-destinations/new-york/start.html
@@ -30,7 +30,7 @@
     --->
   <div class="nav-container">
     <nav class="newNav">
-      <a href="#" class="nav__logo" data-aos="fade-right">Tourguide<span>.</span></a>
+      <a href="#" class="nav__logo" data-aos="fade-right" style="text-decoration: none;">Tourguide<span>.</span></a>
 
       <ul class="navLinks">
         <li class="link home" data-aos="fade-down"><a href="../../index.html#Home">Home</a></li>

--- a/dedicated-destinations/santorini-aegean-sea/start.html
+++ b/dedicated-destinations/santorini-aegean-sea/start.html
@@ -29,7 +29,7 @@
     --->
   <div class="nav-container">
     <nav class="newNav">
-      <a href="#" class="nav__logo" data-aos="fade-right">Tourguide<span>.</span></a>
+      <a href="#" class="nav__logo" data-aos="fade-right" style="text-decoration: none;">Tourguide<span>.</span></a>
 
       <ul class="navLinks">
         <li class="link home" data-aos="fade-down"><a href="../../index.html#Home">Home</a></li>


### PR DESCRIPTION
# Title and Issue number 

Title : Underline removed from the logo in each of the links of the different destinations in the "Best trip package" page.

Issue No. : #587 

Code Stack : HTML | CSS

Close #587 

# Description
The underline in the each destination's logo is removed.


# Video/Screenshots (mandatory)

<img width="920" alt="image" src="https://github.com/apu52/Travel_Website/assets/110184554/3d5d7190-f963-492d-8d5a-fbfccd9e12d2">

# Type of PR

- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Checklist:

- [X] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have gone through the  `contributing.md` file before contributing

# Additional context:
The underline in the logo in each of destinations is removed in "Best Trip Package" page.

*Are you contributing under any Open-source programme?*
I am a GSSOC'24 Contributor.




