### PR TITLE
feat: Resolved Dark Mode Persistance Issue After refreshing

### DIFF
--- a/Theme.js
+++ b/Theme.js
@@ -16,18 +16,28 @@
 const themeToggle = document.getElementById("themeToggle");
 const themeLabel = document.querySelector(".toggle-label");
 
-themeToggle.addEventListener("change", () => {
-  document.body.classList.toggle("dark-theme");
-
-  if (document.body.classList.contains("dark-theme")) {
-    themeLabel.style.background = "#fff"; // Adjust color for the checked state as needed
-    console.log("Dark theme");
-    document.body.classList.remove("dark-theme");
-    document.body.classList.add("light-theme");
-  } else {
-    themeLabel.style.background = "var(--primary-color)"; // Adjust color for the unchecked state as needed
-    console.log("Light theme");
-    document.body.classList.remove("light-theme");
+function applyTheme(theme) {
+  if (theme === "dark") {
     document.body.classList.add("dark-theme");
+    document.body.classList.remove("light-theme");
+    themeLabel.style.background = "var(--primary-color)";
+    themeToggle.checked = true;
+  } else {
+    document.body.classList.add("light-theme");
+    document.body.classList.remove("dark-theme");
+    themeLabel.style.background = "#fff";
+    themeToggle.checked = false; 
   }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  const savedTheme = localStorage.getItem("theme") || "light"; 
+  applyTheme(savedTheme);
 });
+
+themeToggle.addEventListener("change", () => {
+  const theme = themeToggle.checked ? "dark" : "light";
+  localStorage.setItem("theme", theme); 
+  applyTheme(theme);
+});
+


### PR DESCRIPTION
Hi @apu52,
Title : Dark mode gets turned off on refeshing a page
Issue Close #732 

## Description
I have resolved the issue to persist the dark mode preference across page refreshes using localStorage.
The changes ensure that the user's selected mode (dark or light) is maintained even after the page is refreshed.
Please take a look and review it.

## Changes made :
- To make the dark mode preference persist across page refreshes, used "localStorage" to save the user's preference.
- Then Saved the theme preference in localStorage whenever the theme is toggled.
- and then Checked the saved theme preference when the page loads and apply it accordingly.

# Video/Screenshots (mandatory)

https://github.com/apu52/Travel_Website/assets/131389695/8a466c0e-1ac4-48fa-8408-a028b67f4988

# Type of PR

- [x] Bug fix
- [x] Feature enhancement

# Checklist:

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have gone through the  `contributing.md` file before contributing
<!-- [X] - put a cross/X inside [] to check the box -->

##Are you contributing under any Open-source programme?
GSSOC'24

Could you please review and also give required labels? 