### PR TITLE
To fix border of "CONTACT US" image section in Dark Mode

### DIFF
--- a/explore.css
+++ b/explore.css
@@ -1,5 +1,6 @@
 * {
     box-sizing: border-box;
+    /* ADDED BORDER RADIUS IN IMAGE SECTION */
     border-radius: 20px;
   }
   

--- a/explore.css
+++ b/explore.css
@@ -1,5 +1,6 @@
 * {
     box-sizing: border-box;
+    border-radius: 20px;
   }
   
   .outer-box {


### PR DESCRIPTION
# Title and Issue number 
Title : To fix border of "CONTACT US" image section in Dark Mode

Issue No. : #615

Code Stack :  CSS

Close #615

# Description
<!--Please include a brief description of the changes or features added-->
I have fixed the issue of border in "CONTACT US" image section in Dark Mode

# Video/Screenshots (mandatory)
<!--Please try to attach the working video of your new deployed project here -->
![Screenshot 2024-06-07 231027](https://github.com/apu52/Travel_Website/assets/165069293/302b44f2-b777-46c3-9379-9d26f1a77f0d)


# Type of PR  - BUG FIX


# Checklist:

- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have gone through the  `contributing.md` file before contributing
<!-- [X] - put a cross/X inside [] to check the box -->


# Additional context:
<!--Include any additional information or context that might be helpful for reviewers.-->

##Are you contributing under any Open-source program?
Yes, I am contributing under GSSOC 2024.




