### PR TITLE
fix: Fixing Overlap Between Chatbot and Scroll-to-Top Button

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2187,8 +2187,8 @@ body {
   height: 50px;
   background-color: #002152;
   bottom: 20px;
-  right: 25px;
-  bottom: 80px;
+  left: 25px;
+  bottom: 17px;
   border-radius: 50%;
   box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
   text-decoration: none;


### PR DESCRIPTION
Hi @apu52,
closes #754 

considering the current positioning where the chatbot is in the rightmost bottom of the page and the scroll-to-top button is just above it, I adjusted the scroll-to-top button to be moved to the left side of the page to avoid overlap.


******Video/Screenshots (mandatory)******

Here as you can see :
![image](https://github.com/apu52/Travel_Website/assets/160386036/585be320-b9d0-4738-a5e4-111b9c6beeaa)



Please take a look and also add required labels.