### PR TITLE
feat: Automatically add label to issues

### DIFF
--- a/.github/workflows/label-issues.yaml
+++ b/.github/workflows/label-issues.yaml
@@ -1,0 +1,30 @@
+name: Label Issues Based on Template
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  label-issues:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if issue needs a label
+        id: check_label
+        run: |
+          echo "Checking labels for issue #${{ github.event.issue.number }}"
+
+          if [[ "${{ github.event.issue.body }}" == *"I'm a GSSOC'24 contributor"* ]]; then
+            echo "::set-output name=label::gssoc"
+          elif [[ "${{ github.event.issue.body }}" == *"I'm a VSOC'24 contributor"* ]]; then
+            echo "::set-output name=label::VSoC'24"
+          else
+            echo "::set-output name=label::"
+          fi
+
+      - name: Apply Label
+        if: steps.check_label.outputs.label != ''
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: ${{ steps.check_label.outputs.label }}


### PR DESCRIPTION
# Title and Issue number 
<!-- Please make sure issue number is mention in Pull Request else PR will not be merged. -->
Title : Automatically add label to issues

Issue No. : #952 

Close #952 
<!-- Example Close #244  -->
<!-- Replace `issue_no` with the issue number which is fixed in this PR -->


# Description
<!--Please include a brief description of the changes or features added-->

When a user creates a new issue,
based on the user selecting "I'm a GSSOC'24 contributor" or "I'm a VSOC'24 contributor" ,
automatically "gssoc" or "VSoC'24" label is added respectively .

# Video/Screenshots (mandatory)
<!--Please try to attach the working video of your new deployed project here -->
![image](https://github.com/user-attachments/assets/fedbe090-0f00-43d8-b884-2b4e8f1bdbcb)


# Type of PR

- [ ] Bug fix
- [X] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________


# Checklist:

- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have gone through the  `contributing.md` file before contributing
<!-- [X] - put a cross/X inside [] to check the box -->


# Additional context:
<!--Include any additional information or context that might be helpful for reviewers.-->

##Are you contributing under any Open-source programme?
This contribution is under GSSOC'24

- [X] I am contributing under `GSSOC'24`
- [ ] I am contributing under `VSOC'24`

<!-- [X] - put a cross/X inside [] to check the box -->


