### PR TITLE
feat: Added dark mode effects on the FAQ page.

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -146,6 +146,31 @@
       pointer-events: none;
       z-index: 9999;
     }
+    body.dark-theme .accordion{
+      background-color: #040565;
+    }
+    body.dark-theme #btn-style{
+      border: 2px solid red;
+      color: #fdbb2dbf
+    }
+    body.dark-theme .accordion__title{
+      color: white;
+    }
+    body.light-theme .accordion__title{
+      color: black;
+    }
+    body.dark-theme .accordion__question{
+      color: white;
+    }
+    body.light-theme .accordion__question{
+      color: black;
+    }
+    body.dark-theme .accordion__answer{
+      color: white;
+    }
+    body.light-theme .accordion__answer{
+      color: black;
+    }
     </style>
   <link rel="stylesheet" href="imstyle.css">
   <link rel="stylesheet" href="jquery.flipster.min.css">
@@ -286,7 +311,7 @@
 
 
   <!-- --FAQ-- -->
-    <div class="accordion__wrapper">
+    <div class="accordion__wrapper" id="acc">
       <h1 class="accordion__title">Frequently Asked Questions</h1>
   
       <!-- Accordion 1 -->


### PR DESCRIPTION
# Title and Issue number 
Title : No effect of the dark mode on the FAQ page .

Issue No. : #1022

Code Stack : CSS,HTML,JavaScript

Close #1022
<!-- Example Close #244  -->
<!-- Replace `issue_no` with the issue number which is fixed in this PR -->


# Description
I have added dark mode effects on the FAQ page similar to other pages .


# Video/Screenshots (mandatory)
![Screenshot (735)](https://github.com/user-attachments/assets/48387ef2-293e-488b-9a58-964d0b40f951)
![Screenshot (736)](https://github.com/user-attachments/assets/fb0b12b2-07c4-4ad8-8bc6-9dfbcfe46d20)



# Type of PR

- [ ] Bug fix
- [x] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________


# Checklist:

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have gone through the  `contributing.md` file before contributing
<!-- [X] - put a cross/X inside [] to check the box -->


# Additional context:
I have made the dark mode effects similar to the home page , for instance the buttons on the navbar .

##Are you contributing under any Open-source programme?
Yes GSSoC'24.

- [x] I am contributing under `GSSOC'24`
- [ ] I am contributing under `VSOC'24`

<!-- [X] - put a cross/X inside [] to check the box -->


