### PR TITLE
feat: 🌟Added "Licensing page" reflecting "MIT License"

### DIFF
--- a/Licensing.html
+++ b/Licensing.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Licensing Page</title>
+
+    <style>
+        body {
+    font-family: 'Lato', sans-serif;
+    background: linear-gradient(to bottom, #080f21, #06255b);
+    color: #ffffff;
+    margin: 0;
+    padding: 0;
+}
+
+.container {
+    max-width: 70%;
+    margin: 50px auto;
+    padding: 20px;
+    border-radius: 10px;
+}
+
+.container .title {
+    font-size: 4.3em;
+    color: #13b8e6;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    margin-bottom: 20px;
+    font-weight: 700;
+    text-align: center;
+}
+
+.container .section-title {
+    text-align: left;
+    font-size: 2em;
+    color: #0dcaf0;
+    margin-top: 20px;
+}
+
+.container .license-text {
+    font-size: 1.2em;
+    line-height: 1.6;
+    color: #f0f0f0;
+    margin-bottom: 20px;
+    text-align: left;
+}
+
+.container hr {
+    width: 50%;
+    color: #d56fa1;
+    opacity: 0.3;
+    margin: 20px auto;
+}
+
+@media (max-width: 768px) {
+    .container .title {
+        font-size: 2em;
+    }
+
+    .container .section-title {
+        font-size: 1.5em;
+    }
+
+    .container .license-text {
+        font-size: 1em;
+    }
+}
+
+.copyright-footer {
+    display: flex;
+    justify-content: center;
+    margin-top: 25px;
+    font-size: 17px;
+    color: rgb(185, 185, 185);
+}
+
+    </style>
+</head>
+<body>
+    <a href="index.html">
+        <img src="./img/Screenshot 2024-01-23 003448.png" style="width: 130px; border-radius: 6px; margin-top: 20px; margin-left: 20px;">
+    </a>
+    <div class="container">
+        <h1 class="title">Licensing Page</h1>
+        <div class="license-text">
+            <h2 class="section-title">MIT License</h2>
+            <p>Copyright (c) 2023 Arpan Chowdhury</p>
+            <p>Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:</p>
+            <p>The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.</p>
+            <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.</p>
+        </div>
+        <hr>
+        <footer class="copyright-footer">
+            <p>&copy; 2023 Arpan Chowdhury. All rights reserved.</p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1322,6 +1322,7 @@
             <p><a href="./faq.html" class="footer__link">FAQs</a></p>
             <p><a href="./tnc.html" class="footer__link">Terms & Conditions</a></p>
             <p><a href="./privacy.html" class="footer__link">Privacy Policy</a></p>
+            <p><a href="./Licensing.html" class="footer__link">Licensing</a></p>
             <p><a href="#cnt-form" class="footer__link">Contact Us</a></p>
           </div>
         </div>


### PR DESCRIPTION
Hey @apu52 and @itsekta
Issue closes #1031 

Here's what I did -

-    Added a Dedicated Licensing Page
-    Added styling to it so that it will follow the color theme of website
-    I also added a "back to home" button
-    I Added the navigating link in the footer


******Video/Screenshot:******

![image](https://github.com/user-attachments/assets/93cdecbb-cf59-491b-a49f-74b4355b569b)


![346674936-7f674849-aa44-4c3d-aa57-df8edb0c8689](https://github.com/user-attachments/assets/2abbdce6-68b4-4fd2-8411-81bf9d46f4c9)


![346675365-c5869710-3d83-415d-bbbd-62d52d5cb775](https://github.com/user-attachments/assets/9ba71b73-4c5b-4b3e-8563-8188c6021624)


****Please take a look and review it****