### PR TITLE
fix: Fevicon not visible on all html pages #1431

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" type="image/x-icon" href="favicon.ico"/>
     <title>Error Page not found</title>
 </head>
 <body>

--- a/HoneyMoon.html
+++ b/HoneyMoon.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
     integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA=="
     crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico"/>
   <style>
     .newNav{
       opacity:1 !important;

--- a/Licensing.html
+++ b/Licensing.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Licensing Page</title>
     <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <link rel="icon" type="image/x-icon" href="favicon.ico"/>
     <style>
 
         body {

--- a/Signup.html
+++ b/Signup.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Signup</title>
     <link rel="stylesheet" href="login.css"/>
+    <link rel="icon" type="image/x-icon" href="favicon.ico"/>
 </head>
 <body>
     <div class="container">

--- a/about.html
+++ b/about.html
@@ -7,6 +7,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="about.css">
+    <link rel="icon" type="image/x-icon" href="favicon.ico"/>
 </head>
 <body>
     <div class="background">

--- a/contributors.html
+++ b/contributors.html
@@ -21,6 +21,7 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+    <link rel="icon" type="image/x-icon" href="favicon.ico"/>
 
     <style>
       html {

--- a/newLogin.html
+++ b/newLogin.html
@@ -9,6 +9,7 @@
   <link href="https://cdn.lineicons.com/4.0/lineicons.css" rel="stylesheet" />
   <script src="https://kit.fontawesome.com/f2e55912f8.js" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="./login/login.css">
+  <link rel="icon" type="image/x-icon" href="favicon.ico"/>
 </head>
 <body>
   <div id="loginSuccessBanner" class="success-banner">Logged in successfully</div>

--- a/packages.html
+++ b/packages.html
@@ -8,6 +8,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="styles.css" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico"/>
     <style>
         :root {
             --primary-color: #d6eaf7;

--- a/thankyou.html
+++ b/thankyou.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Thankyou</title>
     <link rel="stylesheet" href="thankyou.css">
+    <link rel="icon" type="image/x-icon" href="favicon.ico"/>
 </head>
 <body>
     <div class="container">

--- a/tnc.html
+++ b/tnc.html
@@ -17,6 +17,7 @@
     crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link href="https://cdn.jsdelivr.net/npm/remixicon@3.2.0/fonts/remixicon.css" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
+    <link rel="icon" type="image/x-icon" href="favicon.ico"/>
 
 <style>
     .circle {

--- a/topdeals/topdeals.html
+++ b/topdeals/topdeals.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" type="image/x-icon" href="favicon.ico"/>
   
     <title>Top Deals</title>
     <style>


### PR DESCRIPTION
# Fevicon not visible on all html pages #1431 
Title : Fevicon not visible on all html pages 

Issue No. : 1431 

Close #1431 


# Description
Added missing favicon to html pages below:
1. 404
2. about
3. contributors
4. HoneyMoon
5. Licensing
6. newLogin
7. packages
8. Signup
9. thankyou
10. tnc
11. topdeal


# Video/Screenshots (mandatory)
![Screenshot 2024-10-20 144928](https://github.com/user-attachments/assets/f7b0fed8-5e73-43fb-a3c4-84e96b415e3b)
![Screenshot 2024-10-20 144948](https://github.com/user-attachments/assets/25a21fc0-2ab1-419c-9f2d-9ea04fed01f9)

**(AND OTHERS)**


# Type of PR

- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________


# Checklist:

- [X] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have gone through the  `contributing.md` file before contributing
- [X] I have Starred the Repository.
<!-- [X] - put a cross/X inside [] to check the box -->


##Are you contributing under any Open-source programme?
<!--Mention it here-->

- [X] I am contributing under `GSSOC'24 Extended`
- [X] I am contributing under `Hacktoberfest'24`

<!-- [X] - put a cross/X inside [] to check the box -->


