### PR TITLE
fix: Scroll back button smoothly scrolling issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -2187,10 +2187,8 @@ setInterval(() => {
     <a class="goupbtn" href="#" onclick="goToTop()"><i class="fa-solid fa-arrow-up"></i></a>
 
     <script>
-      // Get the button
       var mybutton = document.querySelector(".goupbtn");
-
-      // When the user scrolls, check if the button should be displayed
+    
       window.addEventListener("scroll", function () {
         if (window.scrollY > 20) {
           mybutton.style.display = "block";
@@ -2198,13 +2196,32 @@ setInterval(() => {
           mybutton.style.display = "none";
         }
       });
-
-      // When the user clicks on the button, scroll to the top of the document
+    
       function goToTop() {
-        document.body.scrollTop = 0; // For Safari
-        document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
+        const currentScroll = window.scrollY;
+        const startTime = performance.now();
+        const duration = 500;
+    
+        function scrollAnimation(currentTime) {
+          const elapsedTime = currentTime - startTime;
+          const progress = Math.min(elapsedTime / duration, 1);
+          const easeOut = progress * (2 - progress);
+          const scrollPosition = currentScroll * (1 - easeOut);
+    
+          window.scrollTo(0, scrollPosition);
+    
+          if (progress < 1) {
+            requestAnimationFrame(scrollAnimation);
+          }
+        }
+    
+        requestAnimationFrame(scrollAnimation);
       }
+    
+      mybutton.addEventListener('click', goToTop);
     </script>
+    
+    
 
 
 


### PR DESCRIPTION
Title :The scroll-back button directly jumps to the top; it does not scroll smoothly to the top. 

Issue No. : #1455 


# Description
Now go to top button is scrolling smoothly instead of jumping to the top


# Video/Screenshots (mandatory)

Before:

[before.webm](https://github.com/user-attachments/assets/66c111a1-ac73-4cb4-9770-d7dc93fbbd42)


After:

[after.webm](https://github.com/user-attachments/assets/c73e4cbd-6c5a-4a3f-9d8e-c88ffcf629fd)


# Type of PR

- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________


# Checklist:

- [X] I have performed a self-review of my code.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.


##Are you contributing under any Open-source programme?

- [X] I am contributing under `GSSOC'24 Extended`
- [X] I am contributing under `Hacktoberfest'24`
