### PR TITLE
Update label-issues.yaml

### DIFF
--- a/.github/workflows/label-issues.yaml
+++ b/.github/workflows/label-issues.yaml
@@ -13,18 +13,17 @@ jobs:
         id: check_label
         run: |
           echo "Checking labels for issue #${{ github.event.issue.number }}"
-
-          if [[ "${{ github.event.issue.body }}" == *"I'm a GSSOC'24 contributor"* ]]; then
-            echo "::set-output name=label::gssoc"
-          elif [[ "${{ github.event.issue.body }}" == *"I'm a VSOC'24 contributor"* ]]; then
-            echo "::set-output name=label::VSoC'24"
+          if [[ "${{ github.event.issue.body || '' }}" == *"I'm a GSSOC'24 contributor"* ]]; then
+            echo "label=gssoc" >> $GITHUB_ENV
+          elif [[ "${{ github.event.issue.body || '' }}" == *"I'm a VSOC'24 contributor"* ]]; then
+            echo "label=VSoC'24" >> $GITHUB_ENV
           else
-            echo "::set-output name=label::"
+            echo "label=" >> $GITHUB_ENV
           fi
 
       - name: Apply Label
-        if: steps.check_label.outputs.label != ''
+        if: env.label != ''
         uses: actions-ecosystem/action-add-labels@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: ${{ steps.check_label.outputs.label }}
+          labels: ${{ env.label }}


### PR DESCRIPTION
Trigger: Runs when an issue is created or edited.
Step 1: Check Content:
Searches the issue body for specific phrases like "I'm a GSSOC'24 contributor". Sets a label (gssoc, VSoC'24, or none) using $GITHUB_ENV. Step 2: Apply Label:
Adds the label to the issue if one is determined in Step 1. Uses a third-party action (actions-ecosystem/action-add-labels) to apply the label. Purpose
Automates issue labeling to save time and ensure consistency. Useful for event-specific tagging like GSSoC or Hacktoberfest. Fix Highlights
Replaced deprecated ::set-output with $GITHUB_ENV. Handles empty issue bodies gracefully.

# Title and Issue number 
<!-- Please make sure issue number is mention in Pull Request else PR will not be merged. -->
Title : Enhance 'Plan a Trip' Page with Interactive 'Read More' Buttons for Detailed Tourist Insights

Issue No. :  #1675

Code Stack : Frontend (HTML, CSS, JavaScript)

Close #1675
<!-- Example Close #244  -->
<!-- Replace `issue_no` with the issue number which is fixed in this PR -->


# Description
This pull request adds interactive "Read More" buttons to the "Plan a Trip" page. These buttons allow users to view detailed information about tourist destinations when needed, keeping the page clean and organized. This enhancement improves the user experience by enabling easy access to more information in a collapsible or modal view.


# Video/Screenshots (mandatory)
<!--Please try to attach the working video of your new deployed project here -

Uploading video.mp4…

->


# Type of PR

- [ ] Bug fix
- [X ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________


# Checklist:

- [X ] I have performed a self-review of my code.
- [X ] I have commented my code, particularly in hard-to-understand areas.
- [X ] I have tested the changes thoroughly before submitting this pull request.
- [X ] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [ X] I have gone through the  `contributing.md` file before contributing
- [X ] I have Starred the Repository.
<!-- [X] - put a cross/X inside [] to check the box -->


# Additional context:
This feature improves the "Plan a Trip" page's usability and design by making detailed tourist information accessible only when needed. It enhances interactivity while maintaining a clean layout.

##Are you contributing under any Open-source programme?
<!--Mention it here-->

- [X ] I am contributing under ` KWOC 2024`
- [ ] I am contributing under ` SWOC 2025`


<!-- [X] - put a cross/X inside [] to check the box -->


