### PR TITLE
fix: images not displaying in trip cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -1073,44 +1073,54 @@
           </p>
           <div class="trip__grid">
             <div class="trip__card cardd tilt-effect">
-              <img src="https://i.ibb.co/60nvYwQ/Screenshot-2023-07-14-173347.png" alt="trip" height="250" width="45" />
+              <img src="./img/santorini-view.jpg" alt="Santorini, Aegean Sea" height="250" />
               <div class="trip__details">
                 <p>Santorini, Aegean Sea</p>
                 <div class="rating"><i class="ri-star-fill"></i> 4.2</div>
                 <div class="booking__price">
                   <div class="price"><span>From</span> $300</div>
-                  <a href="./dedicated-destinations/santorini-aegean-sea/start.html"><button class="book__now btn-style"
-                      style="box-shadow: 2px 2px 8px red;">Book
-                      Now</button></a>
+                  <a href="./dedicated-destinations/santorini-aegean-sea/start.html">
+                    <button class="book__now btn-style" style="box-shadow: 2px 2px 8px red;">
+                      Book Now
+                    </button>
+                  </a>
                 </div>
               </div>
             </div>
+
             <div class="trip__card cardd tilt-effect">
-              <img src="https://i.ibb.co/h1WgH8B/Screenshot-2023-07-14-173807.png" alt="trip" height="250" width="45" />
+              <img src="./img/peru.jpg" alt="Machu Picchu, Peru" height="250" />
               <div class="trip__details">
                 <p>Machu Picchu, Peru</p>
                 <div class="rating"><i class="ri-star-fill"></i> 4.5</div>
                 <div class="booking__price">
                   <div class="price"><span>From</span> $450</div>
-                  <a href="./dedicated-destinations/machu-picchu-peru/Machu_start.html"><button
-                      class="book__now btn-style" style="box-shadow: 2px 2px 8px red;">Book
-                      Now</button></a>
+                  <a href="./dedicated-destinations/machu-picchu-peru/Machu_start.html">
+                    <button class="book__now btn-style" style="box-shadow: 2px 2px 8px red;">
+                      Book Now
+                    </button>
+                  </a>
                 </div>
               </div>
             </div>
+
             <div class="trip__card cardd tilt-effect">
-              <img src="https://i.ibb.co/vc2W0wN/Screenshot-2023-07-14-174151.png" alt="trip" height="250" width="45" />
+              <img src="./img/grandcanyon.jpg" alt="Grand Canyon National Park, Arizona" height="250" />
               <div class="trip__details">
                 <p>Grand Canyon National Park, Arizona</p>
                 <div class="rating"><i class="ri-star-fill"></i> 4.7</div>
                 <div class="booking__price">
                   <div class="price"><span>From</span> $400</div>
-                  <a href="./dedicated-destinations/grand-canyon-national-park-arizona/Grand_start.html"><button
-                      class="book__now btn-style" style="box-shadow: 2px 2px 8px red;">Book Now</button></a>
+                  <a href="./dedicated-destinations/grand-canyon-national-park-arizona/Grand_start.html">
+                    <button class="book__now btn-style" style="box-shadow: 2px 2px 8px red;">
+                      Book Now
+                    </button>
+                  </a>
                 </div>
               </div>
             </div>
           </div>
+
           <div class="view__all">
             <a href="./package.html"><button class="btn" id="btn-style" style="box-shadow: 2px 2px 8px red;">View
                 All</button></a>


### PR DESCRIPTION
# Title and Issue number

fix: images not displaying in trip cards


Issue No. : 1888

Code Stack : HTML, CSS

Close 


# Description

This PR fixes the issue where images were not displaying in the trip cards section.
The problem was caused by broken external image URLs. These have been replaced
with local images from the `/img` directory to ensure reliable loading,
especially on GitHub Pages.


# Video/Screenshots (mandatory)
Trip card images loading correctly after fix:
<img width="1910" height="911" alt="Screenshot 2025-12-18 220359" src="https://github.com/user-attachments/assets/69abfd84-1aea-4bdb-a2e9-897aa1eba66b" />


<!-- (After submitting PR, upload a screenshot here) -->


# Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________


# Checklist:

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have gone through the `contributing.md` file before contributing.
- [x] I have Starred the Repository.


# Additional context:

This change removes dependency on third-party image hosting and improves
stability and maintainability of the project.


## Are you contributing under any Open-source programme?

- [ ] I am contributing under `APERTRE 2025`
- [ ] I am contributing under `CODEPEAK 2025`
- [x] I am contributing under `KWOC 2025`

